### PR TITLE
Added checks for external initialization to all model files so that they may be incorporated as headers for other firmware projects (e.g. tmk))

### DIFF
--- a/hw_interface.h
+++ b/hw_interface.h
@@ -11,6 +11,7 @@ void release_rows(void);
 bool probe_column(uint8_t col);
 void update_leds(uint8_t keyboard_leds);
 void keyboard_init(void);
+void pins_init(void);
 void poll_timer_setup(void);
 void poll_timer_enable(void);
 void poll_timer_disable(void);

--- a/models/common.h
+++ b/models/common.h
@@ -7,6 +7,7 @@
 #include <avr/interrupt.h>
 #include <util/delay.h>
 
+#ifndef __EXTERNAL_INIT__
 /* Extra definitions for AVR stuff. */
 #include "../lib/avr_extra.h"
 /* include keycode definitions. */
@@ -14,6 +15,7 @@
 
 #define STR_MANUFACTURER L"Bathroom Epiphanies, Costar Keyboard -"
 #define VENDOR_ID        0x16C0
+#endif
 
 #define NUMBER_OF_ROWS     18
 #define NUMBER_OF_COLUMNS   8

--- a/models/flake_20130602.h
+++ b/models/flake_20130602.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"CM Storm Quick Fire Rapid"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTB
 #define ROW_MASK  0b01111110

--- a/models/flake_20140521.h
+++ b/models/flake_20140521.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"CM Storm Quick Fire Rapid"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01111011

--- a/models/hoof_20131001.h
+++ b/models/hoof_20131001.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"Filco Majestouch TKL"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01111011

--- a/models/hoof_20150108.h
+++ b/models/hoof_20150108.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"Filco Majestouch TKL"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01111011

--- a/models/paw_20130602.h
+++ b/models/paw_20130602.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"Filco Majestouch"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01110111

--- a/models/petal_20131001.h
+++ b/models/petal_20131001.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"Rosewill"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01110111

--- a/models/squid_20140518.h
+++ b/models/squid_20140518.h
@@ -5,8 +5,10 @@
 
 #include "common.h"
 
+#ifndef __EXTERNAL_INIT__
 #define STR_PRODUCT      L"CM Storm Quick Fire XT"
 #define PRODUCT_ID       0x047D
+#endif
 
 #define ROW_PORT  PORTD
 #define ROW_MASK  0b01111110


### PR DESCRIPTION
Having the board definitions in separate header files is very useful, as well as the functions for probe_column, etc... for example integrated with TMK firmware here:

https://github.com/bgould/costar_tmk_keyboard

Please let me know if you would like me to make any changes in order to get this incorporated.  This seems like a better way than manually porting each of the controllers individually
